### PR TITLE
Extend `clean` Makefile target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+clean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O);
+	cd _build; git worktree add -f html gh-pages
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
With these changes running `make clean` will rebuild the HTML pages after the build directory has been cleaned. It should include new additions to the source files.