### PR TITLE
Set include patterns for Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ pythonpath = [
 
 [tool.ruff]
 line-length = 79
+include = ["src/*/*.py", "tests/*.py"]
 
 [tool.ruff.lint]
 # Here we list the styling/formatting rules that Ruff should use.


### PR DESCRIPTION
We currently don't want Ruff to scan every directory for Python files, as everyone's setup is different and notebooks are a mess anyway. I have added explicit patterns for Ruff to scan and check the Python files in the `src` and the `tests` directory.