### PR TITLE
Add ruff to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,31 @@ jobs:
       - name: Run tests
         run: tox
 
+  linting:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade .[lint]
+
+      - name: Run ruff
+        run: ruff check --output-format github
+
   finalise:
     runs-on: ubuntu-latest
-    needs: [testing]
+    needs: [testing, linting]
     steps:
       - name: finalise
         run: echo "All done"


### PR DESCRIPTION
Pull requests now trigger ruff's linting, and the CI should yield an error if a contribution does not satisfy our style guide.