### PR TITLE
Fix the squareness check of the covariance matrix

### DIFF
--- a/src/derivkit/forecast_kit.py
+++ b/src/derivkit/forecast_kit.py
@@ -64,7 +64,12 @@ class ForecastKit:
         """
         self.function = function
         self.central_values = np.atleast_1d(central_values)
-        if not covariance_matrix.shape[0] == covariance_matrix.shape[1]:
+        if not covariance_matrix.ndim < 3:
+            raise ValueError(
+                        "covariance_matrix must be at most two-dimensional but "
+                        f"dimensions is {covariance_matrix.ndim}."
+            )
+        if covariance_matrix.ndim == 2 and not covariance_matrix.shape[0] == covariance_matrix.shape[1]:
             raise ValueError("covariance_matrix must be a square numpy array.")
         self.covariance_matrix = covariance_matrix
         self.n_parameters = len(self.central_values)


### PR DESCRIPTION
The covariance matrix can be one-dimensional if there is a single observable. However, the test in `ForecastKit` will fail. I have split the test into two: one to ensure that the dimensionality is at most two, and one to ensure that if the dimensionality is two that the matrix is square.