### PR TITLE
Remove "_static" from html_static_path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,4 +30,4 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_static_path = ['_static']
+html_static_path = []


### PR DESCRIPTION
Since the `_static` directory should exist under the `gh-pages` branch (in `docs/_build/html`) this appears to create a warning. Since warnings are translated to failures due to #47 this will cause the deployment of the documentation to fail.

Generating the docs locally with `html_static_path` set to an empty array appears to resolve the warning. This PR implements this fix for the main branch.