### PR TITLE
Fix rST issue

### DIFF
--- a/src/derivkit/adaptive/__init__.py
+++ b/src/derivkit/adaptive/__init__.py
@@ -2,6 +2,7 @@
 
 This subpackage provides tools for derivative estimation via adaptive
 polynomial fitting. It contains:
+
 - `fit_core`: core adaptive fitting implementation
 - `fallback`: fallback strategies when fitting fails
 - `grid`, `offsets`, `weights`: utilities for building evaluation grids and weights

--- a/src/derivkit/adaptive/grid.py
+++ b/src/derivkit/adaptive/grid.py
@@ -1,6 +1,7 @@
 """Offset grid builders for adaptive sampling around ``x0``.
 
 This module works with *relative* offsets (around 0). You typically:
+
 1) Start from a small set of strictly positive seed offsets near zero;
 2) Mirror them to obtain a symmetric grid about 0 (optionally including 0);
 3) If that symmetric grid is too small for a stable fit, extend the positive


### PR DESCRIPTION
Lists must be preceded by an empty line in rST. This was missing here, which caused Sphinx to panic.