### PR TITLE
docs: fix homepage usage example (closes #85)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,8 +41,8 @@ Quick Start
 
   dk = DerivativeKit(
     function=simple_function,
-    central_value=1.0,
-    derivative_order=1
+    x0=1.0,
+    order=1
   )
   print("Adaptive:", dk.adaptive.compute())
   print("Finite Difference:", dk.finite.compute())

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,11 +41,10 @@ Quick Start
 
   dk = DerivativeKit(
     function=simple_function,
-    x0=1.0,
-    order=1
+    x0=1.0
   )
-  print("Adaptive:", dk.adaptive.compute())
-  print("Finite Difference:", dk.finite.compute())
+  print("Adaptive:", dk.adaptive.differentiate(order=1))
+  print("Finite Difference:", dk.finite.differentiate(order=1))
 
 
 Adaptive Fit Example


### PR DESCRIPTION
This PR updates the documentation to fix the homepage usage example. The old snippet was outdated with the previous API; it now reflects the current AdaptiveFitDerivative interface.

**Changes**
Corrected function call in the docs

**Issue**
Closes #85