### PR TITLE
Change Callable import source to collections.abc

### DIFF
--- a/src/derivkit/adaptive/batch_eval.py
+++ b/src/derivkit/adaptive/batch_eval.py
@@ -7,7 +7,8 @@ and diagnostics (e.g., in `AdaptiveFitDerivative`).
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 from multiprocess import Pool

--- a/src/derivkit/adaptive/estimator.py
+++ b/src/derivkit/adaptive/estimator.py
@@ -16,8 +16,9 @@ path.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import numpy as np
 

--- a/src/derivkit/adaptive/fallback.py
+++ b/src/derivkit/adaptive/fallback.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 

--- a/src/derivkit/adaptive/grid.py
+++ b/src/derivkit/adaptive/grid.py
@@ -11,7 +11,8 @@ This module works with *relative* offsets (around 0). You typically:
 
 from __future__ import annotations
 
-from typing import Callable, Tuple
+from collections.abc import Callable
+from typing import Tuple
 
 import numpy as np
 

--- a/src/derivkit/adaptive_fit.py
+++ b/src/derivkit/adaptive_fit.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 import numpy as np
 

--- a/src/derivkit/derivative_kit.py
+++ b/src/derivkit/derivative_kit.py
@@ -14,7 +14,7 @@ Typical usage example:
 derivative is the derivative of function_to_differerentiate at value 1.
 """
 
-from typing import Callable
+from collections.abc import Callable
 
 from derivkit.adaptive_fit import AdaptiveFitDerivative
 from derivkit.finite_difference import FiniteDifferenceDerivative

--- a/src/derivkit/forecast_kit.py
+++ b/src/derivkit/forecast_kit.py
@@ -10,7 +10,8 @@ Typical usage example:
 >>> G, H = forecaster.dali()
 """
 
-from typing import Callable, Sequence
+from collections.abc import Callable
+from typing import Sequence
 
 import numpy as np
 

--- a/src/derivkit/utils.py
+++ b/src/derivkit/utils.py
@@ -8,7 +8,8 @@ symmetry checks, and example/test function generators.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 


### PR DESCRIPTION
The `Callable` type from the Typing library is deprecated (see https://docs.python.org/3/library/typing.html#typing.Callable).

Solves #81 