### PR TITLE
Remove Tuple class with tuple builtin

### DIFF
--- a/src/derivkit/adaptive/estimator.py
+++ b/src/derivkit/adaptive/estimator.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional
 
 import numpy as np
 
@@ -54,7 +54,7 @@ def _maybe_accept_at_floor(
     fit_tolerance: float,
     fallback_mode: str,
     floor_accept_multiplier: float,
-) -> Tuple[bool, str]:
+) -> tuple[bool, str]:
     """Decide whether to accept a fit at the minimum sample count ("floor").
 
     Invoked when pruning cannot further reduce residuals and the algorithm is
@@ -70,7 +70,7 @@ def _maybe_accept_at_floor(
         deciding acceptance under "auto".
 
     Returns:
-      Tuple[bool, str]: ``(accept, tag)`` where ``accept`` indicates
+      tuple[bool, str]: ``(accept, tag)`` where ``accept`` indicates
       acceptance and ``tag`` is the chosen mode label for diagnostics.
     """
     if not at_floor:
@@ -100,7 +100,7 @@ def prune_by_residuals(
     max_remove: int = 2,
     keep_center: bool = True,
     keep_symmetric: bool = True,
-) -> Tuple[np.ndarray, np.ndarray, bool]:
+) -> tuple[np.ndarray, np.ndarray, bool]:
     """Remove worst residuals (and optional mirrors) above tolerance.
 
     Removes up to ``max_remove`` points whose residuals exceed ``fit_tolerance``,
@@ -119,7 +119,7 @@ def prune_by_residuals(
       keep_symmetric: Whether to remove symmetric mirrors when possible.
 
     Returns:
-      Tuple[np.ndarray, np.ndarray, bool]: ``(x_kept, y_kept, removed_any)``,
+      tuple[np.ndarray, np.ndarray, bool]: ``(x_kept, y_kept, removed_any)``,
       where ``removed_any`` indicates whether any point was pruned.
 
     Raises:

--- a/src/derivkit/adaptive/fit_core.py
+++ b/src/derivkit/adaptive/fit_core.py
@@ -9,7 +9,7 @@ d^m/dx^m = (1 / h^m) * d^m/du^m evaluated at u = 0.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-def normalize_coords(x_vals: np.ndarray, x0: float) -> Tuple[np.ndarray, float]:
+def normalize_coords(x_vals: np.ndarray, x0: float) -> tuple[np.ndarray, float]:
     """Normalize coordinates around ``x0`` to roughly ``[-1, 1]``.
 
     Shifts samples by ``x0`` and scales by the maximum absolute deviation
@@ -40,7 +40,7 @@ def normalize_coords(x_vals: np.ndarray, x0: float) -> Tuple[np.ndarray, float]:
       x0: Expansion point.
 
     Returns:
-      Tuple[np.ndarray, float]: ``(u_vals, h)`` where ``u_vals`` are the
+      tuple[np.ndarray, float]: ``(u_vals, h)`` where ``u_vals`` are the
       normalized coordinates and ``h`` is the scaling factor.
     """
     t = np.asarray(x_vals, dtype=float) - float(x0)
@@ -88,7 +88,7 @@ def residuals_relative(
     y_fit: np.ndarray,
     y_true: np.ndarray,
     floor: float = 1e-8,
-) -> Tuple[np.ndarray, float]:
+) -> tuple[np.ndarray, float]:
     """Compute elementwise relative residuals and their maximum.
 
     Uses ``|y_fit − y_true| / max(|y_true|, floor)`` to avoid division by very
@@ -100,7 +100,7 @@ def residuals_relative(
       floor: Denominator floor to prevent blow-ups near zero.
 
     Returns:
-      Tuple[np.ndarray, float]: ``(residuals, rel_error)`` where
+      tuple[np.ndarray, float]: ``(residuals, rel_error)`` where
       ``rel_error`` is ``residuals.max()`` (or ``0.0`` if empty).
     """
     y_true = np.asarray(y_true, float)

--- a/src/derivkit/adaptive/grid.py
+++ b/src/derivkit/adaptive/grid.py
@@ -12,7 +12,6 @@ This module works with *relative* offsets (around 0). You typically:
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Tuple
 
 import numpy as np
 
@@ -98,7 +97,7 @@ def build_x_offsets(
     min_samples: int,
     min_used_points: int,
     get_adaptive_offsets: Callable[..., np.ndarray] = _default_get_adaptive_offsets,
-) -> Tuple[np.ndarray, int]:
+) -> tuple[np.ndarray, int]:
     """Build the symmetric relative grid and compute ``required_points``.
 
     ``required_points`` is the minimum total samples the fit loop may use:

--- a/src/derivkit/forecasting/expansions.py
+++ b/src/derivkit/forecasting/expansions.py
@@ -325,7 +325,7 @@ class LikelihoodExpansion:
             invcov (np.ndarray): Inverse covariance of observables, shape (N, N).
 
         Returns:
-            Tuple[np.ndarray, np.ndarray]: G with shape (P, P, P) and H with shape (P, P, P, P).
+            tuple[np.ndarray, np.ndarray]: G with shape (P, P, P) and H with shape (P, P, P, P).
         """
         # G_abc = Σ_ij d2[a,b,i] invcov[i,j] d1[c,j]
         g_tensor = np.einsum("abi,ij,cj->abc", d2, invcov, d1)


### PR DESCRIPTION
The Tuple class from the typing library is deprecated (see https://docs.python.org/3/library/typing.html#typing.Tuple).