### PR TITLE
Move get_partial_function to utils

### DIFF
--- a/docs/Makefile 2
+++ b/docs/Makefile 2
@@ -1,0 +1,24 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O);
+	cd _build; git worktree add -f html gh-pages
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf 2.py
+++ b/docs/conf 2.py
@@ -1,0 +1,35 @@
+"""Sphinx configuration for the DerivKit documentation."""
+
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "Derivkit"
+copyright = "2025, Nikolina Šarčević"
+author = "Nikolina Šarčević"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+html_favicon = "assets/favicon.png"
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.githubpages",
+]
+
+autoclass_content = "both"
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_static_path = []

--- a/docs/contributing 2.rst
+++ b/docs/contributing 2.rst
@@ -1,0 +1,94 @@
+.. _contributing:
+
+############
+Contributing
+############
+
+Contributions in any shape or form are appreciated.
+Below are some minimal guidelines to get started.
+
+Development of ``derivkit`` is organised around `the Github repository <https://github.com/derivkit/derivkit>`__.
+Contributing usually requires `setting up an account <https://github.com/signup>`__ on Github.
+No worries, it's free of charge!
+
+When submitting contributions, please write in clear and correct English using full sentences.
+Be concise and avoid unnecessarily formulaic descriptions.
+
+***********************
+Submitting bugs or code
+***********************
+
+Submitting a bug report or feature request can be done by `opening an issue on Github <https://github.com/derivkit/derivkit/issues/new/choose>`__.
+In the case of a bug report please make sure to
+
+- describe the expected behaviour,
+- describe the actual behaviour,
+- the version(s) of ``derivkit`` that produce the bug,
+- any specific environmnent details.
+
+In the case of a feature please make sure to
+
+- describe the feature,
+- describe the need of the feature.
+
+Submitting a code contribution can be done by `opening a pull request on Github <https://github.com/derivkit/derivkit/compare>`__.
+In the pull request, please make sure of the following:
+
+- The description of the pull request contains a high-level overview of what is implemented in the contribution.
+- The description describes the reason for the addition.
+  Specifically, it describes what problem it is supposed to solve.
+  If the pull requests resolves a bug or implements a feature for which an issue exists, make sure to refer to this.
+- The ``derivkit`` workflows completed successfully.
+  The workflows will activate when a pull request is created, but can also be run locally on your computer as described below
+
+******************************
+Running ``derivkit`` workflows
+******************************
+
+``derivkit`` uses `tox <https://tox.wiki>`__ to run its workflows.
+It is installed along with  ``derivkit`` itself.
+
+All workflows can be run consecutively by simply calling tox from the project root directory::
+
+  tox
+
+Specific workflows can also be run in isolation.
+The following workflows are provided:
+
+=======
+Linting
+=======
+
+Code for ``derivkit`` must comply with `PEP-8 <https://peps.python.org/pep-0008/>`__.
+Comments and docstrings must be compatible with `Google-style comments and docstrings <https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings>`__.
+
+The linting workflow can be run using::
+
+  tox -e lint
+
+=============
+Documentation
+=============
+
+Documentation written in `reStructuredText <https://docutils.sourceforge.io/rst.html>`__ (rST).
+Code documentation is generated from docstrings, and can be generated automatically::
+
+  tox -e docs
+
+Newly created rST files may need to be added to the appropriate table of contents files by hand.
+
+=======
+Testing
+=======
+
+Contributions that contain new code must include tests in the appropriate files in the ``tests`` directory.
+The test suite can be run locally by simply running tox on the command line::
+
+  tox -m test
+
+Note that this will attempt to run the test suite for all supported Python version.
+It will automatically skip versions which aren't locally available.
+If the test suite must be run for a specific version of Python that specific environment must be called.
+For example, to test against Python 3.13::
+
+  tox -e py313

--- a/docs/derivkit 2.rst
+++ b/docs/derivkit 2.rst
@@ -1,0 +1,25 @@
+derivkit package
+================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   derivkit.adaptive
+   derivkit.adaptive_fit
+   derivkit.derivative_kit
+   derivkit.finite_difference
+   derivkit.forecasting
+   derivkit.forecast_kit
+   derivkit.forecasting.expansions
+   derivkit.utils
+
+Module contents
+---------------
+
+.. automodule:: derivkit
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive 2.rst
+++ b/docs/derivkit.adaptive 2.rst
@@ -1,0 +1,26 @@
+derivkit.adaptive package
+=========================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   derivkit.adaptive.batch_eval
+   derivkit.adaptive.diagnostics
+   derivkit.adaptive.estimator
+   derivkit.adaptive.fallback
+   derivkit.adaptive.fit_core
+   derivkit.adaptive.grid
+   derivkit.adaptive.offsets
+   derivkit.adaptive.validate
+   derivkit.adaptive.weights
+
+Module contents
+---------------
+
+.. automodule:: derivkit.adaptive
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.batch_eval 2.rst
+++ b/docs/derivkit.adaptive.batch_eval 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.batch\_eval module
+====================================
+
+.. automodule:: derivkit.adaptive.batch_eval
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.diagnostics 2.rst
+++ b/docs/derivkit.adaptive.diagnostics 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.diagnostics module
+====================================
+
+.. automodule:: derivkit.adaptive.diagnostics
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.estimator 2.rst
+++ b/docs/derivkit.adaptive.estimator 2.rst
@@ -1,0 +1,8 @@
+derivkit.adaptive.estimator module
+==================================
+
+.. automodule:: derivkit.adaptive.estimator
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :exclude-members:  value, mode, x_used, y_used, y_fit, residuals, status

--- a/docs/derivkit.adaptive.fallback 2.rst
+++ b/docs/derivkit.adaptive.fallback 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.fallback module
+=================================
+
+.. automodule:: derivkit.adaptive.fallback
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.fit_core 2.rst
+++ b/docs/derivkit.adaptive.fit_core 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.fit\_core module
+==================================
+
+.. automodule:: derivkit.adaptive.fit_core
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.grid 2.rst
+++ b/docs/derivkit.adaptive.grid 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.grid module
+=============================
+
+.. automodule:: derivkit.adaptive.grid
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.offsets 2.rst
+++ b/docs/derivkit.adaptive.offsets 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.offsets module
+================================
+
+.. automodule:: derivkit.adaptive.offsets
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.validate 2.rst
+++ b/docs/derivkit.adaptive.validate 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.validate module
+=================================
+
+.. automodule:: derivkit.adaptive.validate
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.adaptive.weights 2.rst
+++ b/docs/derivkit.adaptive.weights 2.rst
@@ -1,0 +1,7 @@
+derivkit.adaptive.weights module
+================================
+
+.. automodule:: derivkit.adaptive.weights
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.derivative_kit 2.rst
+++ b/docs/derivkit.derivative_kit 2.rst
@@ -1,0 +1,7 @@
+derivkit.derivative\_kit module
+===============================
+
+.. automodule:: derivkit.derivative_kit
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.finite_difference 2.rst
+++ b/docs/derivkit.finite_difference 2.rst
@@ -1,0 +1,7 @@
+derivkit.finite\_difference module
+==================================
+
+.. automodule:: derivkit.finite_difference
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.forecast_kit 2.rst
+++ b/docs/derivkit.forecast_kit 2.rst
@@ -1,0 +1,7 @@
+derivkit.forecast\_kit module
+=============================
+
+.. automodule:: derivkit.forecast_kit
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.forecasting 2.rst
+++ b/docs/derivkit.forecasting 2.rst
@@ -1,0 +1,20 @@
+derivkit.forecasting package
+============================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   derivkit.forecasting.calculus
+   derivkit.forecasting.expansions
+   derivkit.forecasting.likelihoods
+
+Module contents
+---------------
+
+.. automodule:: derivkit.forecasting
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.forecasting.calculus 2.rst
+++ b/docs/derivkit.forecasting.calculus 2.rst
@@ -1,0 +1,7 @@
+derivkit.forecasting.calculus module
+====================================
+
+.. automodule:: derivkit.forecasting.calculus
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.forecasting.expansions 2.rst
+++ b/docs/derivkit.forecasting.expansions 2.rst
@@ -1,0 +1,7 @@
+derivkit.forecasting.expansions module
+======================================
+
+.. automodule:: derivkit.forecasting.expansions
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.forecasting.likelihoods 2.rst
+++ b/docs/derivkit.forecasting.likelihoods 2.rst
@@ -1,0 +1,7 @@
+derivkit.forecasting.likelihoods module
+=======================================
+
+.. automodule:: derivkit.forecasting.likelihoods
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/derivkit.utils 2.rst
+++ b/docs/derivkit.utils 2.rst
@@ -1,0 +1,7 @@
+derivkit.utils module
+=====================
+
+.. automodule:: derivkit.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/index 2.rst
+++ b/docs/index 2.rst
@@ -1,0 +1,84 @@
+.. Derivkit documentation master file, created by
+   sphinx-quickstart on Wed Aug 20 20:21:28 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Derivkit documentation
+======================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+   contributing
+
+**DerivKit** is a robust Python toolkit for stable numerical derivatives, built for scientific computing, cosmology, and any domain requiring accurate gradients or higher-order expansions.
+
+It provides:
+
+* Adaptive polynomial fitting that excludes noisy points based on residuals,
+* High-order finite differences for accurate stencil-based derivatives,
+* A simple API for comparing both approaches side by side.
+
+Detailed documentation of the toolkit's modules can be found in the sidebar.
+
+Installation
+------------
+
+::
+
+   pip install derivkit
+
+Quick Start
+-----------
+
+::
+
+  from derivkit import DerivativeKit
+
+  def simple_function(x):
+      return x**2 + x
+
+  dk = DerivativeKit(
+    function=simple_function,
+    x0=1.0
+  )
+  print("Adaptive:", dk.adaptive.differentiate(order=1))
+  print("Finite Difference:", dk.finite.differentiate(order=1))
+
+
+Adaptive Fit Example
+--------------------
+
+Below is a visual example of the :py:mod:`derivkit.adaptive_fit` module estimating the first derivative of a nonlinear function in the presence of noise.
+The method selectively discards outlier points before fitting a polynomial, resulting in a robust and smooth estimate.
+
+.. image:: assets/plots/adaptive_fit_with_noise_order1_demo_func.png
+
+
+Citation
+--------
+
+If you use ``derivkit`` in your research, please cite it as follows:
+
+::
+
+  @software{sarcevic2025derivkit,
+    author       = {Nikolina Šarčević and Matthijs van der Wild},
+    title        = {derivkit: A Python Toolkit for Numerical Derivatives},
+    year         = {2025},
+    publisher    = {GitHub},
+    journal      = {GitHub Repository},
+    howpublished = {\url{https://github.com/derivkit/derivkit}},
+  }
+
+Contributing
+------------
+
+Interested in getting involved?
+Have a look at :ref:`contributing`!
+
+License
+-------
+MIT License © 2025 Niko Šarčević, Matthijs van der Wild

--- a/docs/make 2.bat
+++ b/docs/make 2.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules 2.rst
+++ b/docs/modules 2.rst
@@ -1,0 +1,7 @@
+derivkit
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   derivkit

--- a/src/derivkit/forecasting/expansions.py
+++ b/src/derivkit/forecasting/expansions.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 import numpy as np
 
 from derivkit.derivative_kit import DerivativeKit
+from derivkit.utils import get_partial_function
 
 
 class LikelihoodExpansion:
@@ -172,7 +173,7 @@ class LikelihoodExpansion:
             for m in range(self.n_parameters):
                 # 1 parameter to differentiate, and n_parameters-1 parameters to hold fixed
                 theta0_x = deepcopy(self.theta0)
-                function_to_diff = self._get_partial_function(
+                function_to_diff = get_partial_function(
                     self.function, m, theta0_x
                 )
                 kit = DerivativeKit(function_to_diff, self.theta0[m])
@@ -190,7 +191,7 @@ class LikelihoodExpansion:
                     if m1 == m2:
                         # 1 parameter to differentiate twice, and n_parameters-1 parameters to hold fixed
                         theta0_x = deepcopy(self.theta0)
-                        function_to_diff1 = self._get_partial_function(
+                        function_to_diff1 = get_partial_function(
                             self.function, m1, theta0_x
                         )
                         kit1 = DerivativeKit(
@@ -207,7 +208,7 @@ class LikelihoodExpansion:
                         def function_to_diff2(y):
                             theta0_y = deepcopy(self.theta0)
                             theta0_y[m2] = y
-                            function_to_diff1 = self._get_partial_function(
+                            function_to_diff1 = get_partial_function(
                                 self.function, m1, theta0_y
                             )
                             kit1 = DerivativeKit(
@@ -227,36 +228,6 @@ class LikelihoodExpansion:
             return second_order_derivatives
 
         raise RuntimeError("Unreachable code reached in get_forecast_tensors.")
-
-    def _get_partial_function(
-        self, full_function, variable_index, fixed_values
-    ):
-        """Returns a single-variable version of a multivariate function.
-
-        A single parameter must be specified by index. All others parameters
-        are held fixed.
-
-        Args:
-            full_function (callable): A function that takes a list of
-                n_parameters parameters and returns a vector of n_observables
-                observables.
-            variable_index (int): The index of the parameter to treat as the
-                variable.
-            fixed_values (list or np.ndarray): The list of parameter values to
-                use as fixed inputs for all parameters except the one being
-                varied.
-
-        Returns:
-            callable: A function of a single variable, suitable for use in
-                differentiation.
-        """
-
-        def partial_function(x):
-            params = deepcopy(fixed_values)
-            params[variable_index] = x
-            return np.atleast_1d(full_function(params))
-
-        return partial_function
 
     def _inv_cov(self):
         """Return the inverse covariance matrix with minimal diagnostics.

--- a/src/derivkit/utils.py
+++ b/src/derivkit/utils.py
@@ -9,6 +9,7 @@ symmetry checks, and example/test function generators.
 from __future__ import annotations
 
 from collections.abc import Callable
+from copy import deepcopy
 from typing import Any
 
 import numpy as np
@@ -20,6 +21,7 @@ __all__ = [
     "central_difference_error_estimate",
     "is_symmetric_grid",
     "generate_test_function",
+    "get_partial_function",
 ]
 
 
@@ -143,3 +145,35 @@ def generate_test_function(name: str = "sin"):
     if name == "sin":
         return lambda x: np.sin(x), lambda x: np.cos(x), lambda x: -np.sin(x)
     raise ValueError(f"Unknown test function: {name!r}")
+
+def get_partial_function(
+        full_function: Callable,
+        variable_index: int,
+        fixed_values: list | np.ndarray,
+) -> Callable:
+    """Returns a single-variable version of a multivariate function.
+
+    A single parameter must be specified by index. All others parameters
+    are held fixed.
+
+    Args:
+        full_function (callable): A function that takes a list of
+            n_parameters parameters and returns a vector of n_observables
+            observables.
+        variable_index (int): The index of the parameter to treat as the
+            variable.
+        fixed_values (list or np.ndarray): The list of parameter values to
+            use as fixed inputs for all parameters except the one being
+            varied.
+
+    Returns:
+        callable: A function of a single variable, suitable for use in
+            differentiation.
+    """
+
+    def partial_function(x):
+        params = deepcopy(fixed_values)
+        params[variable_index] = x
+        return np.atleast_1d(full_function(params))
+
+    return partial_function

--- a/tests/test_forecastkit.py
+++ b/tests/test_forecastkit.py
@@ -202,5 +202,6 @@ def test_forecast(
     assert numpy.allclose(fisher_matrix, expected_fisher, atol=0)
 
     dali_g, dali_h = forecaster.dali()
+
     assert numpy.allclose(dali_g, expected_dali_g, atol=0)
     assert numpy.allclose(dali_h, expected_dali_h, atol=0)


### PR DESCRIPTION
This PR refactors the code by moving the get_partial_function helper into utils.py so it can be reused consistently across modules. No functional changes, only code organization.