### PR TITLE
Tests(#80): add coverage for DerivativeKit and finite-difference

### DIFF
--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -1,0 +1,108 @@
+"""Tests for DerivativeKit wrapper."""
+
+import numpy as np
+
+from derivkit.derivative_kit import DerivativeKit
+
+
+def test_constructor_wires_adaptive_and_finite(monkeypatch):
+    """Both calculators are constructed with the same (function, x0)."""
+    calls = {"adaptive": None, "finite": None}
+
+    class FakeAdaptive:
+        def __init__(self, function, x0, **kwargs):  # noqa: D401
+            calls["adaptive"] = (function, x0, kwargs)
+
+        def differentiate(self, **kwargs):  # not used here
+            return 0.0
+
+    class FakeFinite:
+        def __init__(self, function, x0, **kwargs):  # noqa: D401
+            calls["finite"] = (function, x0, kwargs)
+
+    # Patch module-local symbols used by DerivativeKit
+    monkeypatch.setattr(
+        "derivkit.derivative_kit.AdaptiveFitDerivative",
+        FakeAdaptive,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "derivkit.derivative_kit.FiniteDifferenceDerivative",
+        FakeFinite,
+        raising=True,
+    )
+
+    def f(x):
+        return x
+
+    dk = DerivativeKit(f, 0.5)
+
+    assert calls["adaptive"][0] is f and np.isclose(calls["adaptive"][1], 0.5)
+    assert calls["finite"][0] is f and np.isclose(calls["finite"][1], 0.5)
+    assert isinstance(dk.adaptive, FakeAdaptive)
+    assert isinstance(dk.finite, FakeFinite)
+
+
+def test_get_used_points_plumbs_diagnostics(monkeypatch):
+    """get_used_points must request diagnostics and unpack them correctly."""
+    captured = {"called": False, "kwargs": None}
+
+    class FakeAdaptive:
+        def __init__(self, *args, **kwargs):  # noqa: D401
+            pass
+
+        def differentiate(self, *, order, diagnostics, n_workers, **_):
+            captured["called"] = True
+            captured["kwargs"] = {
+                "order": order,
+                "diagnostics": diagnostics,
+                "n_workers": n_workers,
+            }
+
+            # Diagnostics payload matching DerivativeKit expectations
+            M, C = 5, 1
+            diag = {
+                "x_all": np.linspace(0.0, 1.0, M),
+                "y_all": np.linspace(10.0, 20.0, M).reshape(M, C),
+                "x_used": [np.array([0.0, 0.25, 0.5])],
+                "y_used": [np.array([10.0, 12.5, 15.0])],
+                "used_mask": [np.array([True, False, True, True, False])],
+            }
+            return 0.0, diag
+
+    class FakeFinite:
+        def __init__(self, *args, **kwargs):  # noqa: D401
+            pass
+
+    monkeypatch.setattr(
+        "derivkit.derivative_kit.AdaptiveFitDerivative",
+        FakeAdaptive,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "derivkit.derivative_kit.FiniteDifferenceDerivative",
+        FakeFinite,
+        raising=True,
+    )
+
+    dk = DerivativeKit(lambda x: x, 0.0)
+    x_all, y_all, x_used, y_used, used_mask = dk.get_used_points(
+        order=2, n_workers=3
+    )
+
+    # Ensure diagnostics=True and kwargs forwarded
+    assert captured["called"] is True
+    assert captured["kwargs"] == {
+        "order": 2,
+        "diagnostics": True,
+        "n_workers": 3,
+    }
+
+    # Shapes & basic value checks
+    assert x_all.shape == (5,)
+    assert y_all.shape == (5,)
+    assert x_used.shape == (3,)
+    assert y_used.shape == (3,)
+    assert used_mask.shape == (5,)
+    np.testing.assert_allclose(x_used, np.array([0.0, 0.25, 0.5]))
+    assert used_mask.dtype == bool

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -58,6 +58,11 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
     """
     captured = {"called": False, "kwargs": None}
 
+    # Sizes used by the fake diagnostics payload
+    m = 5  # total sample count
+    c = 1  # number of columns in y_all
+    k = 3  # number of "used" points
+
     class FakeAdaptive:
         def __init__(self, *args, **kwargs):
             pass
@@ -69,8 +74,8 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
                 "diagnostics": diagnostics,
                 "n_workers": n_workers,
             }
+
             # Diagnostics payload matching DerivativeKit expectations
-            m, c = 5, 1
             diag = {
                 "x_all": np.linspace(0.0, 1.0, m),
                 "y_all": np.linspace(10.0, 20.0, m).reshape(m, c),
@@ -98,10 +103,10 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
     assert captured["kwargs"] == {"order": order, "diagnostics": True, "n_workers": n_workers}
 
     # Shapes & basic value checks
-    assert x_all.shape == (5,)
-    assert y_all.shape == (5,)
-    assert x_used.shape == (3,)
-    assert y_used.shape == (3,)
-    assert used_mask.shape == (5,)
+    assert x_all.shape == (m,)
+    assert y_all.shape == (m,)
+    assert x_used.shape == (k,)
+    assert y_used.shape == (k,)
+    assert used_mask.shape == (m,)
     np.testing.assert_allclose(x_used, np.array([0.0, 0.25, 0.5]))
     assert used_mask.dtype == bool

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -44,7 +44,11 @@ def test_constructor_wires_adaptive_and_finite(monkeypatch):
 
 
 def test_get_used_points_plumbs_diagnostics(monkeypatch):
-    """get_used_points must request diagnostics and unpack them correctly."""
+    """get_used_points forwards kwargs and parses diagnostics.
+
+    Forwards (order, n_workers), requests diagnostics=True, and returns parsed
+    (x_all, y_all, x_used, y_used, used_mask).
+    """
     captured = {"called": False, "kwargs": None}
 
     class FakeAdaptive:

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -17,14 +17,14 @@ def test_constructor_wires_adaptive_and_finite(monkeypatch):
     calls = {"adaptive": None, "finite": None}
 
     class FakeAdaptive:
-        def __init__(self, function, x0, **kwargs):  # noqa: D401
+        def __init__(self, function, x0, **kwargs):
             calls["adaptive"] = (function, x0, kwargs)
 
         def differentiate(self, **kwargs):  # not used here
             return 0.0
 
     class FakeFinite:
-        def __init__(self, function, x0, **kwargs):  # noqa: D401
+        def __init__(self, function, x0, **kwargs):
             calls["finite"] = (function, x0, kwargs)
 
     # Patch module-local symbols used by DerivativeKit

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -57,10 +57,12 @@ def test_constructor_wires_adaptive_and_finite(monkeypatch):
 
 
 def test_get_used_points_plumbs_diagnostics(monkeypatch):
-    """get_used_points forwards kwargs and parses diagnostics.
+    """Ensure `get_used_points` forwards kwargs, forces diagnostics, and parses outputs.
 
-    Forwards (order, n_workers), requests diagnostics=True, and returns parsed
-    (x_all, y_all, x_used, y_used, used_mask).
+    Asserts:
+      * `AdaptiveFitDerivative.differentiate` is called with (order, n_workers) and diagnostics=True.
+      * Returned arrays have expected shapes: len(x_all)=len(y_all)=M, len(x_used)=len(y_used)=K,
+        len(used_mask)=M and dtype=bool.
     """
     captured = {"called": False, "kwargs": None}
 

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -6,7 +6,7 @@ from derivkit.derivative_kit import DerivativeKit
 
 
 def test_constructor_wires_adaptive_and_finite(monkeypatch):
-    """Both calculators are constructed with the same (function, x0)."""
+    """DerivativeKit constructs Adaptive/Finite with identical (function, x0) and stores them."""
     calls = {"adaptive": None, "finite": None}
 
     class FakeAdaptive:

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -69,12 +69,11 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
                 "diagnostics": diagnostics,
                 "n_workers": n_workers,
             }
-
             # Diagnostics payload matching DerivativeKit expectations
-            M, C = 5, 1
+            m, c = 5, 1
             diag = {
-                "x_all": np.linspace(0.0, 1.0, M),
-                "y_all": np.linspace(10.0, 20.0, M).reshape(M, C),
+                "x_all": np.linspace(0.0, 1.0, m),
+                "y_all": np.linspace(10.0, 20.0, m).reshape(m, c),
                 "x_used": [np.array([0.0, 0.25, 0.5])],
                 "y_used": [np.array([10.0, 12.5, 15.0])],
                 "used_mask": [np.array([True, False, True, True, False])],
@@ -85,29 +84,16 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-    monkeypatch.setattr(
-        "derivkit.derivative_kit.AdaptiveFitDerivative",
-        FakeAdaptive,
-        raising=True,
-    )
-    monkeypatch.setattr(
-        "derivkit.derivative_kit.FiniteDifferenceDerivative",
-        FakeFinite,
-        raising=True,
-    )
+    # Patch immediately after defining the fakes
+    monkeypatch.setattr("derivkit.derivative_kit.AdaptiveFitDerivative", FakeAdaptive, raising=True)
+    monkeypatch.setattr("derivkit.derivative_kit.FiniteDifferenceDerivative", FakeFinite, raising=True)
 
     dk = DerivativeKit(lambda x: x, 0.0)
-    x_all, y_all, x_used, y_used, used_mask = dk.get_used_points(
-        order=2, n_workers=3
-    )
+    x_all, y_all, x_used, y_used, used_mask = dk.get_used_points(order=2, n_workers=3)
 
     # Ensure diagnostics=True and kwargs forwarded
     assert captured["called"] is True
-    assert captured["kwargs"] == {
-        "order": 2,
-        "diagnostics": True,
-        "n_workers": 3,
-    }
+    assert captured["kwargs"] == {"order": 2, "diagnostics": True, "n_workers": 3}
 
     # Shapes & basic value checks
     assert x_all.shape == (5,)

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -87,7 +87,6 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
 
     # Patch immediately after defining the fakes
     monkeypatch.setattr("derivkit.derivative_kit.AdaptiveFitDerivative", FakeAdaptive, raising=True)
-    monkeypatch.setattr("derivkit.derivative_kit.FiniteDifferenceDerivative", FakeFinite, raising=True)
 
     dk = DerivativeKit(lambda x: x, 0.0)
     order = 2

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -1,8 +1,15 @@
 """Tests for DerivativeKit wrapper."""
 
+from functools import partial
+
 import numpy as np
 
 from derivkit.derivative_kit import DerivativeKit
+
+
+def quad(x, a=2.0, b=-3.0, c=1.5):
+    """Quadratic function for testing."""
+    return a * x**2 + b * x + c
 
 
 def test_constructor_wires_adaptive_and_finite(monkeypatch):
@@ -32,8 +39,8 @@ def test_constructor_wires_adaptive_and_finite(monkeypatch):
         raising=True,
     )
 
-    def f(x):
-        return x
+    a, b, c = 2.0, -3.0, 1.5
+    f = partial(quad, a=a, b=b, c=c)
 
     dk = DerivativeKit(f, 0.5)
 

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -52,7 +52,7 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
     captured = {"called": False, "kwargs": None}
 
     class FakeAdaptive:
-        def __init__(self, *args, **kwargs):  # noqa: D401
+        def __init__(self, *args, **kwargs):
             pass
 
         def differentiate(self, *, order, diagnostics, n_workers, **_):
@@ -75,7 +75,7 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
             return 0.0, diag
 
     class FakeFinite:
-        def __init__(self, *args, **kwargs):  # noqa: D401
+        def __init__(self, *args, **kwargs):
             pass
 
     monkeypatch.setattr(

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -13,7 +13,13 @@ def quad(x, a=2.0, b=-3.0, c=1.5):
 
 
 def test_constructor_wires_adaptive_and_finite(monkeypatch):
-    """DerivativeKit constructs Adaptive/Finite with identical (function, x0) and stores them."""
+    """Ensure Adaptive and Finite receive the same (function, x0) and are stored.
+
+    Checks:
+      * Both constructors are called with identical (f, x0).
+      * Call arguments are recorded correctly.
+      * Instances are attached as `adaptive` and `finite`.
+    """
     calls = {"adaptive": None, "finite": None}
 
     class FakeAdaptive:

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -85,10 +85,6 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
             }
             return 0.0, diag
 
-    class FakeFinite:
-        def __init__(self, *args, **kwargs):
-            pass
-
     # Patch immediately after defining the fakes
     monkeypatch.setattr("derivkit.derivative_kit.AdaptiveFitDerivative", FakeAdaptive, raising=True)
     monkeypatch.setattr("derivkit.derivative_kit.FiniteDifferenceDerivative", FakeFinite, raising=True)

--- a/tests/test_derivative_kit.py
+++ b/tests/test_derivative_kit.py
@@ -89,11 +89,13 @@ def test_get_used_points_plumbs_diagnostics(monkeypatch):
     monkeypatch.setattr("derivkit.derivative_kit.FiniteDifferenceDerivative", FakeFinite, raising=True)
 
     dk = DerivativeKit(lambda x: x, 0.0)
-    x_all, y_all, x_used, y_used, used_mask = dk.get_used_points(order=2, n_workers=3)
+    order = 2
+    n_workers = 3
+    x_all, y_all, x_used, y_used, used_mask = dk.get_used_points(order=order, n_workers=n_workers)
 
     # Ensure diagnostics=True and kwargs forwarded
     assert captured["called"] is True
-    assert captured["kwargs"] == {"order": 2, "diagnostics": True, "n_workers": 3}
+    assert captured["kwargs"] == {"order": order, "diagnostics": True, "n_workers": n_workers}
 
     # Shapes & basic value checks
     assert x_all.shape == (5,)

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -18,3 +18,42 @@ def test_invalid_order_finite():
     """Unsupported derivative order raises ValueError."""
     with pytest.raises(ValueError):
         DerivativeKit(lambda x: x, 1.0).finite.differentiate(order=5)
+
+
+def test_fd_second_derivative_quadratic_constant():
+    """Second derivative of a quadratic is constant: d²/dx² (ax²+bx+c) = 2a."""
+    a, b, c = 3.0, -1.0, 2.0
+
+    def myfunc(x):
+        return a * x**2 + b * x + c
+
+    est = DerivativeKit(myfunc, x0=0.3).finite.differentiate(order=2, num_points=5)
+    assert np.isclose(est, 2 * a, rtol=1e-3, atol=1e-8)
+
+
+def test_vector_output_returns_1d_array():
+    """Multi-component output returns 1D NumPy array of derivatives."""
+
+    def myfunc(x):
+        return np.array([x**2, 2 * x])
+
+    est = DerivativeKit(myfunc, x0=0.5).finite.differentiate(order=1, num_points=5)
+    assert isinstance(est, np.ndarray)
+    assert est.shape == (2,)
+
+
+def test_invalid_stencil_size_raises():
+    """Unsupported stencil size raises ValueError."""
+    with pytest.raises(ValueError):
+        DerivativeKit(lambda x: x, 0.0).finite.differentiate(order=1, num_points=4)  # not in [3,5,7,9]
+
+def test_invalid_combo_stencil_order_raises():
+    """Unsupported (stencil size, order) combination raises ValueError."""
+    # 3-point supports only order=1
+    with pytest.raises(ValueError):
+        DerivativeKit(lambda x: x, 0.0).finite.differentiate(order=2, num_points=3)
+
+def test_scalar_returns_python_float():
+    """Scalar output returns Python float, not 1-element array."""
+    val = DerivativeKit(lambda x: x**2, 1.0).finite.differentiate(order=1, num_points=5)
+    assert isinstance(val, float)


### PR DESCRIPTION
This PR adds focused tests for the core derivative calculators in DerivKit, building on the recent refactor in #112.

**DerivativeKit**

- Tests constructor wiring with AdaptiveFitDerivative and FiniteDifferenceDerivative.
- Verifies get_used_points returns expected structures using monkeypatched diagnostics.

**FiniteDifferenceDerivative**

- Adds functional tests for analytic cases (sin, quadratic).
- Covers vector-valued outputs and invalid order handling.
- These tests strengthen core coverage and directly address issue #80.

**Notes:**

- AdaptiveFitDerivative is already exercised by the adaptive test suite; no duplication here.
- This PR should be merged after #112.