### PR TITLE
Unpack array before function call

### DIFF
--- a/src/derivkit/utils.py
+++ b/src/derivkit/utils.py
@@ -185,6 +185,6 @@ def get_partial_function(
     def partial_function(x):
         params = fixed_arr.copy()
         params[variable_index] = x
-        return np.atleast_1d(full_function(params))
+        return np.atleast_1d(full_function(*params))
 
     return partial_function


### PR DESCRIPTION
In partial_function, the `full_function` will expect `params.size` arguments, but it is given `params`, which is a single array. It will therefore complain if it is given a non-scalar argument. To fix this `params` needs to be unpacked as it is passed to the function.