### PR TITLE
Tests/hessian tests from pr

### DIFF
--- a/src/derivkit/forecasting/calculus.py
+++ b/src/derivkit/forecasting/calculus.py
@@ -225,7 +225,7 @@ def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_
         return kit2.adaptive.differentiate(
                 order=1, n_workers=n_workers
             )
-    
+
 def hessian_diag(*args, **kwargs):
     """This is a placeholder for a Hessian diagonal computation function."""
     raise NotImplementedError

--- a/src/derivkit/forecasting/calculus.py
+++ b/src/derivkit/forecasting/calculus.py
@@ -161,14 +161,14 @@ def hessian(function, theta0, n_workers=1):
     return hess
 
 def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_workers: int) -> float:
-    """Compute one component of the hessian of a vector-valued function.
+    """Compute one component of the hessian of a scalar-valued function.
 
     Helper used by ``hessian``. Wraps ``function`` into a single-variable
     callable via ``derivkit.utils.get_partial_function`` and differentiates it
     with ``DerivativeKit.adaptive.differentiate``.
 
     Args:
-        function: The vector-valued function to
+        function: The scalar-valued function to
             differentiate. It should accept a list or array of parameter
             values as input and return an array of observable values.
         theta0: The points at which the derivative is evaluated.

--- a/src/derivkit/forecasting/calculus.py
+++ b/src/derivkit/forecasting/calculus.py
@@ -138,27 +138,37 @@ def hessian(function, theta0, n_workers=1):
     if theta0.size == 0:
         raise ValueError("theta0 must be a non-empty 1D array.")
 
+    f0 = np.asarray(function(theta0), dtype=float)
+    if f0.size != 1:
+        raise TypeError("hessian() expects a scalar-valued function.")
+
     n_parameters = theta0.size
-    hessian = np.zeros((n_parameters,n_parameters), dtype=float)
+    hess = np.empty((n_parameters, n_parameters), dtype=float)
 
-    # n_workers controls inner 1D differentiation (not across parameters).
+    # Diagonals here (pure second orders)
     for i in range(n_parameters):
-        for j in range(n_parameters):
-            hessian[i][j] = _hessian_component(function, theta0, i, j, n_workers)
+        hess[i, i] = _hessian_component(function, theta0, i, i, n_workers)
 
-    if not np.isfinite(hessian).all():
+    # Off-diagonals here (mixed second orders).
+    for i in range(n_parameters):
+        for j in range(i + 1, n_parameters):
+            hij = _hessian_component(function, theta0, i, j, n_workers)
+            hess[i, j] = hij
+            hess[j, i] = hij
+
+    if not np.isfinite(hess).all():
         raise FloatingPointError("Non-finite values encountered in hessian.")
-    return hessian
+    return hess
 
 def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_workers: int) -> float:
-    """Compute one component of the hessian of a scalar-valued function.
+    """Compute one component of the hessian of a vector-valued function.
 
     Helper used by ``hessian``. Wraps ``function`` into a single-variable
     callable via ``derivkit.utils.get_partial_function`` and differentiates it
     with ``DerivativeKit.adaptive.differentiate``.
 
     Args:
-        function: The scalar-valued function to
+        function: The vector-valued function to
             differentiate. It should accept a list or array of parameter
             values as input and return an array of observable values.
         theta0: The points at which the derivative is evaluated.
@@ -186,7 +196,7 @@ def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_
         probe = np.asarray(partial_vec1(theta0[i]), dtype=float)
         if probe.size != 1:
             raise TypeError(
-                "gradient() expects a scalar-valued function; "
+                "hessian() expects a scalar-valued function; "
                 f"got shape {probe.shape} from full_function(params)."
             )
 
@@ -208,7 +218,7 @@ def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_
             kit1 = DerivativeKit(
                 partial_vec1, theta0[i]
             )
-            return kit1.adaptive.differentiate(order=1)
+            return kit1.adaptive.differentiate(order=1, n_workers=n_workers)
 
         kit2 = DerivativeKit(
             partial_vec2, theta0[j]

--- a/src/derivkit/forecasting/calculus.py
+++ b/src/derivkit/forecasting/calculus.py
@@ -122,9 +122,101 @@ def _jacobian_component(function: Callable, theta0: np.ndarray, i: int, n_worker
     kit = DerivativeKit(partial_vec, theta0[i])
     return kit.adaptive.differentiate(order=1, n_workers=n_workers)
 
-def hessian(*args, **kwargs):
-    """This is a placeholder for a Hessian computation function."""
-    raise NotImplementedError
+def hessian(function, theta0, n_workers=1):
+    """Returns the hessian of a scalar-valued function.
+
+    Args:
+        function (Callable): The function to be differentiated.
+        theta0  (array-like): The parameter vector at which the hessian is evaluated.
+        n_workers (int): Number of workers used by DerivativeKit.adaptive.differentiate.
+                        This setting does not parallelize across parameters.
+
+    Returns:
+        (``np.array``): 2D array representing the hessian.
+    """
+    theta0 = np.asarray(theta0, dtype=float).reshape(-1)
+    if theta0.size == 0:
+        raise ValueError("theta0 must be a non-empty 1D array.")
+
+    n_parameters = theta0.size
+    hessian = np.zeros((n_parameters,n_parameters), dtype=float)
+
+    # n_workers controls inner 1D differentiation (not across parameters).
+    for i in range(n_parameters):
+        for j in range(n_parameters):
+            hessian[i][j] = _hessian_component(function, theta0, i, j, n_workers)
+
+    if not np.isfinite(hessian).all():
+        raise FloatingPointError("Non-finite values encountered in hessian.")
+    return hessian
+
+def _hessian_component(function: Callable, theta0: np.ndarray, i: int, j:int, n_workers: int) -> float:
+    """Compute one component of the hessian of a scalar-valued function.
+
+    Helper used by ``hessian``. Wraps ``function`` into a single-variable
+    callable via ``derivkit.utils.get_partial_function`` and differentiates it
+    with ``DerivativeKit.adaptive.differentiate``.
+
+    Args:
+        function: The scalar-valued function to
+            differentiate. It should accept a list or array of parameter
+            values as input and return an array of observable values.
+        theta0: The points at which the derivative is evaluated.
+            A 1D array or list of parameter values matching the expected
+            input of the function.
+        i: Zero-based index of the first parameter with respect to which to differentiate.
+        j: Zero-based index of the second parameter with respect to which to differentiate.
+        n_workers: Number of workers used inside
+            ``DerivativeKit.adaptive.differentiate``. This does not parallelize
+            across parameters.
+
+    Returns:
+        The ith, jth component of the hessian of function evaluated at ``theta0``.
+
+    Raises:
+        TypeError: If ``function`` does not return a scalar value.
+    """
+    if i == j:
+        # 1 parameter to differentiate twice, and n_parameters-1 parameters to hold fixed
+        partial_vec1 = get_partial_function(
+            function, i, theta0
+        )
+
+        # One-time scalar check for hessian()
+        probe = np.asarray(partial_vec1(theta0[i]), dtype=float)
+        if probe.size != 1:
+            raise TypeError(
+                "gradient() expects a scalar-valued function; "
+                f"got shape {probe.shape} from full_function(params)."
+            )
+
+        kit1 = DerivativeKit(
+            partial_vec1, theta0[i]
+        )
+        return kit1.adaptive.differentiate(
+                order=2, n_workers=n_workers
+            )
+
+    else:
+        # 2 parameters to differentiate once, with other parameters held fixed
+        def partial_vec2(y):
+            theta0_y = theta0.copy()
+            theta0_y[j] = y
+            partial_vec1 = get_partial_function(
+                function, i, theta0_y
+            )
+            kit1 = DerivativeKit(
+                partial_vec1, theta0[i]
+            )
+            return kit1.adaptive.differentiate(order=1)
+
+        kit2 = DerivativeKit(
+            partial_vec2, theta0[j]
+        )
+        return kit2.adaptive.differentiate(
+                order=1, n_workers=n_workers
+            )
+    
 def hessian_diag(*args, **kwargs):
     """This is a placeholder for a Hessian diagonal computation function."""
     raise NotImplementedError

--- a/tests/test_calculus.py
+++ b/tests/test_calculus.py
@@ -1,9 +1,178 @@
-"""Unit tests for forecasting/calculus.py."""
+"""Unit tests for forecasting/calculus.py (Jacobian)."""
 
+import numpy as np
 import pytest
 
+from derivkit.forecasting.calculus import jacobian
 
-@pytest.mark.skip(reason="Pending calculus module: tracked in #116")
-def test_calculus_todo():
-    """Placeholder until forecasting/calculus.py exists; tests will be added then."""
-    pass
+
+def test_jacobian_linear_map():
+    """Test jacobian on a linear map."""
+    # f(theta) = A @ theta  =>  J = A (constant)
+    A = np.array([[1.0, -2.0, 0.5],
+                  [0.0,  3.0, 1.0]])
+    def f(th):
+        th = np.asarray(th, dtype=float)
+        return A @ th
+    theta0 = np.array([0.3, -0.7, 1.2])
+    J = jacobian(f, theta0, n_workers=1)
+    assert J.shape == (A.shape[0], theta0.size)
+    assert np.allclose(J, A, atol=1e-12, rtol=0.0)
+
+
+def test_jacobian_analytic():
+    """Test jacobian on a function with known analytic Jacobian."""
+    # f([x,y]) = [x^2, sin(y), x*y]
+    # J = [[2x,   0 ],
+    #      [ 0 , cos y],
+    #      [ y ,  x  ]]
+    def f(th):
+        x, y = th
+        return np.array([x**2, np.sin(y), x*y], dtype=float)
+    x0, y0 = 0.4, -0.2
+    theta0 = np.array([x0, y0], dtype=float)
+    J = jacobian(f, theta0, n_workers=2)
+    J_true = np.array([[2*x0, 0.0],
+                       [0.0,  np.cos(y0)],
+                       [y0,   x0]], dtype=float)
+    assert J.shape == (3, 2)
+    assert np.allclose(J, J_true, atol=1e-5, rtol=1e-6)
+
+
+def test_jacobian_empty_theta_raises():
+    """Test jacobian raises ValueError on empty theta0."""
+    def f(th):
+        return np.array([1.0])
+    with pytest.raises(ValueError):
+        jacobian(f, np.array([]))
+
+
+def num_jacobian(f, theta, eps=1e-6):
+    """Plain central-diff numerical Jacobian for test reference."""
+    theta = np.asarray(theta, dtype=float)
+    f0 = np.asarray(f(theta), dtype=float)
+    m, n = f0.size, theta.size
+    J = np.empty((m, n), dtype=float)
+    for j in range(n):
+        tp, tm = theta.copy(), theta.copy()
+        tp[j] += eps
+        tm[j] -= eps
+        fp = np.asarray(f(tp), dtype=float)
+        fm = np.asarray(f(tm), dtype=float)
+        J[:, j] = (fp - fm) / (2 * eps)
+    return J
+
+
+def test_jacobian_linear_random_matrix():
+    """For a linear map f(θ)=Aθ, the Jacobian should equal A exactly."""
+    rng = np.random.default_rng(42)
+    A = rng.normal(size=(4, 3))
+    def f(th):
+        return A @ np.asarray(th, dtype=float)
+    theta0 = rng.normal(size=3)
+    J = jacobian(f, theta0, n_workers=1)
+    assert J.shape == (4, 3)
+    assert np.allclose(J, A, atol=1e-12, rtol=0.0)
+
+
+def test_jacobian_matches_numeric_reference():
+    """Nonlinear check vs a simple central-diff reference."""
+    def f(th):
+        x, y, z = th
+        return np.array([
+            x*y + np.sin(z),
+            x**2 + np.cos(y),
+            np.exp(z) * y
+        ], dtype=float)
+
+    theta0 = np.array([0.3, -0.7, 0.25], dtype=float)
+    J = jacobian(f, theta0, n_workers=1)
+    J_ref = num_jacobian(f, theta0, eps=1e-5)
+    # Allow modest tolerance due to different step control in DerivativeKit
+    assert J.shape == (3, 3)
+    assert np.allclose(J, J_ref, atol=8e-5, rtol=5e-6)
+
+
+def test_jacobian_single_output_vector_len1():
+    """Vector-valued function of length 1 should still work and produce shape (1, n)."""
+    def f(th):
+        x, y = th
+        return np.array([x**2 + y], dtype=float)  # length-1 vector
+    theta0 = np.array([0.4, -0.2], dtype=float)
+    J = jacobian(f, theta0, n_workers=1)
+    J_true = np.array([[2*theta0[0], 1.0]])
+    assert J.shape == (1, 2)
+    assert np.allclose(J, J_true, atol=1e-6, rtol=1e-6)
+
+
+def test_jacobian_workers_invariance():
+    """Jacobian should be invariant to n_workers choice (within tolerance)."""
+    def f(th):
+        x, y = th
+        return np.array([x**2, np.sin(y), x*y], dtype=float)
+    theta0 = np.array([0.4, -0.2], dtype=float)
+    J1 = jacobian(f, theta0, n_workers=1)
+    J2 = jacobian(f, theta0, n_workers=3)
+    assert J1.shape == J2.shape == (3, 2)
+    assert np.allclose(J1, J2, atol=2e-6, rtol=2e-6)
+
+
+def test_jacobian_shape_and_type_errors():
+    """Input validation: empty theta should raise; non-array-like output should error upstream."""
+    def f_vec(th):
+        return np.array([1.0, 2.0])
+    with pytest.raises(ValueError):
+        jacobian(f_vec, np.array([]))
+
+
+def test_jacobian_chain_rule_linear_wrapper():
+    """Check chain rule via a linear pre-transform: g(θ)=f(Bθ) ⇒ J_g = J_f|_{Bθ} · B."""
+    B = np.array([[1.0, -1.0],
+                  [0.5,  2.0]])
+    def f(u):
+        # f: R^2 -> R^2
+        x, y = u
+        return np.array([x**2 + y, np.sin(x) + np.cos(y)], dtype=float)
+
+    def g(theta):
+        return f(B @ np.asarray(theta, dtype=float))
+
+    theta0 = np.array([0.2, -0.3], dtype=float)
+    # J_g(θ) (computed)
+    Jg = jacobian(g, theta0, n_workers=1)
+    # J_f(u) at u=Bθ
+    u0 = B @ theta0
+    def f_wrt_u(u):
+        return f(u)
+    Jf = jacobian(f_wrt_u, u0, n_workers=1)  # shape (2,2)
+    Jg_theory = Jf @ B
+    assert np.allclose(Jg, Jg_theory, atol=8e-5, rtol=5e-6)
+
+
+def test_jacobian_raises_on_nonfinite_output():
+    """Jacobian should raise if function returns non-finite values."""
+    def f(th):
+        x, y = th
+        return np.array([x, np.nan*x + y], dtype=float)
+    with pytest.raises((FloatingPointError, ValueError)):
+        jacobian(f, np.array([1.0, 2.0]))
+
+
+def test_jacobian_does_not_modify_input():
+    """Ensure jacobian does not modify theta0 in-place."""
+    def f(th): return np.array([th[0] + th[1]])
+    theta0 = np.array([0.1, 0.2])
+    theta_copy = theta0.copy()
+    _ = jacobian(f, theta0, n_workers=1)
+    assert np.array_equal(theta0, theta_copy)
+
+
+def test_jacobian_accepts_list_and_row_vector():
+    """Ensure jacobian accepts list input and 2D row vector input."""
+    def f(th):
+        x, y = th
+        return np.array([x + y, x - y])
+    J1 = jacobian(f, [0.3, -0.7])
+    J2 = jacobian(f, np.array([[0.3, -0.7]]))  # weird shape
+    assert J1.shape == (2, 2)
+    assert np.allclose(J1, J2)


### PR DESCRIPTION
this  pr adds unit tests for the hessian functions in calculus.py.

the tests build on top  existing Jacobian tests: 

this builds on both the jacobian test suite and the jacobian fix introduced in prs #126 and #129.
extends coverage to close issue #130.