### PR TITLE
Add hessian

### DIFF
--- a/src/derivkit/forecasting/calculus.py
+++ b/src/derivkit/forecasting/calculus.py
@@ -131,14 +131,14 @@ def _jacobian_component(
     kit = DerivativeKit(partial_vec, theta0[i])
     return kit.adaptive.differentiate(order=1, n_workers=n_workers)
 
-def build_hessian(function, theta0, n_workers=1):
+def build_hessian(function: Callable, theta0: np.ndarray, n_workers: int=1):
     """Returns the hessian of a scalar-valued function.
 
     Args:
-        function (Callable): The function to be differentiated.
-        theta0  (array-like): The parameter vector at which the hessian is evaluated.
-        n_workers (int): Number of workers used by DerivativeKit.adaptive.differentiate.
-                        This setting does not parallelize across parameters.
+        function: The function to be differentiated.
+        theta0: The parameter vector at which the hessian is evaluated.
+        n_workers: Number of workers used by DerivativeKit.adaptive.differentiate.
+            This setting does not parallelize across parameters.
 
     Returns:
         (``np.array``): 2D array representing the hessian.


### PR DESCRIPTION
Because #126 became has become a bit messy with all the recent rebasings I have taken the liberty of creating a new PR on a branch that only includes the following commits: 0f8eee086d6543b38a36f6ab63a2494c9fa3fa10, 95c9acee7c25edc809887d57d164f5d17f5cf229, 229b9b0399330733c24493a32306f018da521092, e612c8e6b84aab22f8e7bc4b3a7ad7f11f3b98d2, 6111a16e5bb7bdd2d581f6ccc8f0b298ad61bece.

I have chosen to not include a3ed556012b745585efcf8cba3f73c4a16c961a8 and 56023a670e748cb862b4f9ef5c54e66e0153eb60, because it is not entirely clear what these commits do, and because 75f80f6afa19c940394e54e45d6cb09834738a8c appears to address something in these two commits I have not included it either.

I feel that the unresolved points in my review of #126 still stand, but implementing them requires a larger review of the codebase. It seems that the `i` and `j` inputs in calculating the hessian cannot be simply converted from `int`s to numpy arrays, as this breaks the way the derivatives are computed in `AdaptiveFitDerivative`. Since the current code in calculating the hessian seems correct to me, I would suggest that we leave this for the future.

@nikosarcevic & @ctrendafilova could you have a look to see that between all the rebasing the changes still accurately reflect your work, and that you're happy with this being merged?