### PR TITLE
Add the tabulated model methods to the docs index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,6 +77,7 @@ DerivKit is organized into four layers:
    * Tabulated 1D interpolator
    * Tabulated 1D from table
 
+   Supports scalar, vector or tensor outputs for all derivatives.
    Data can be read from memory or from a text file.
 
 Installation


### PR DESCRIPTION
This is just a small addition that mentions the data interpolator on the front page, without much detail. More details can be found in the API docs. We may want to add more in the guides section.