### PR TITLE
Expansions restructure

### DIFF
--- a/src/derivkit/forecasting/__init__.py
+++ b/src/derivkit/forecasting/__init__.py
@@ -1,3 +1,3 @@
-"""Forecasting utilities (expansions, likelihoods, fisher_bias)."""
+"""Forecasting utilities (expansions, likelihoods, fisher, dali)."""
 
-__all__ = ["expansions", "likelihoods", "fisher_bias"]
+__all__ = ["expansions", "likelihoods", "fisher", "dali"]

--- a/src/derivkit/forecasting/dali.py
+++ b/src/derivkit/forecasting/dali.py
@@ -1,0 +1,47 @@
+"""Provides tools for computing the DALI tensors.
+
+The user must specify the observables, fiducial values, and covariance matrix
+at which the forecast should be evaluated.
+
+More details about available options can be found in the documentation of
+the methods.
+"""
+
+from typing import Any, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from derivkit.calculus_kit import CalculusKit
+from derivkit.utils.linalg import solve_or_pinv
+
+
+def _build_dali(
+        expansion,
+        d1: NDArray[np.float64],
+        d2: NDArray[np.float64],
+        invcov: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Assemble the doublet-DALI tensors (G, H) from first- and second-order derivatives.
+
+    Computes:
+        G_abc = Σ_{i,j} d2[a,b,i] · invcov[i,j] · d1[c,j]
+        H_abcd = Σ_{i,j} d2[a,b,i] · invcov[i,j] · d2[c,d,j]
+
+    Args:
+        d1: First-order derivatives of the observables with respect to parameters,
+            shape (P, N).
+        d2: Second-order derivatives of the observables with respect to parameters,
+            shape (P, P, N).
+        invcov: Inverse covariance matrix of the observables, shape (N, N).
+
+    Returns:
+        A tuple ``(G, H)`` where:
+            - G has shape (P, P, P)
+            - H has shape (P, P, P, P)
+    """
+    # G_abc = Σ_ij d2[a,b,i] invcov[i,j] d1[c,j]
+    g_tensor = np.einsum("abi,ij,cj->abc", d2, invcov, d1)
+    # H_abcd = Σ_ij d2[a,b,i] invcov[i,j] d2[c,d,j]
+    h_tensor = np.einsum("abi,ij,cdj->abcd", d2, invcov, d2)
+    return g_tensor, h_tensor

--- a/src/derivkit/forecasting/fisher.py
+++ b/src/derivkit/forecasting/fisher.py
@@ -1,4 +1,4 @@
-"""Provides tools for computing the Fisher bias for an experimental forecast.
+"""Provides tools for computing the Fisher matrix and Fisher bias.
 
 The user must specify the observables, fiducial values, covariance matrix, and
 "biased" data vector at which the forecast should be evaluated.
@@ -14,6 +14,25 @@ from numpy.typing import NDArray
 
 from derivkit.calculus_kit import CalculusKit
 from derivkit.utils.linalg import solve_or_pinv
+
+
+def _build_fisher(expansion, d1, invcov):
+    """Assemble the Fisher information matrix F from first derivatives.
+
+    Args:
+        d1 (np.ndarray): First-order derivatives of observables w.r.t. parameters,
+            shape (n_parameters, n_observables).
+        invcov (np.ndarray): Inverse covariance of observables,
+            shape (n_observables, n_observables).
+
+    Returns:
+        np.ndarray: Fisher matrix, shape (n_parameters, n_parameters).
+
+    Notes:
+        Uses `np.einsum("ai,ij,bj->ab", d1, invcov, d1)`.
+    """
+    # F_ab = Σ_ij d1[a,i] invcov[i,j] d1[b,j]
+    return np.einsum("ai,ij,bj->ab", d1, invcov, d1)
 
 
 def build_fisher_bias(


### PR DESCRIPTION
Restructuring `expansions.py` to address #195 .

I have separated the two Fisher bias functions -- `build_fisher_bias` and `build_delta_nu` -- into a separate file, `fisher_bias.py`.

This is my first attempt, so please review and give feedback on how to improve the changes.

Also, I didn't know how to correctly specify the `LikelihoodExpansion` type in lines 20 and 137 of `fisher_bias.py`.