### PR TITLE
Split expansions (step 1): move worker/covariance helpers to utils

### DIFF
--- a/src/derivkit/utils/concurrency.py
+++ b/src/derivkit/utils/concurrency.py
@@ -14,6 +14,7 @@ __all__ = [
     "resolve_inner_from_outer",
     "parallel_execute",
     "_inner_workers_var",
+    "normalize_workers",
 ]
 
 
@@ -134,3 +135,22 @@ def parallel_execute(
                 return [f.result() for f in futures]
         else:
             return [worker(*args) for args in arg_tuples]
+
+
+def normalize_workers(n_workers):
+    """Ensure n_workers is a positive integer, defaulting to 1.
+
+    Args:
+        n_workers: Input number of workers (can be None, float, negative, etc.)
+
+    Returns:
+        int: A positive integer number of workers (at least 1).
+
+    Raises:
+        None: Invalid inputs are coerced to 1.
+    """
+    try:
+        n = int(n_workers)
+    except (TypeError, ValueError):
+        n = 1
+    return 1 if n < 1 else n

--- a/src/derivkit/utils/validate.py
+++ b/src/derivkit/utils/validate.py
@@ -13,7 +13,8 @@ from derivkit.utils.sandbox import get_partial_function
 __all__ = [
     "is_finite_and_differentiable",
     "check_scalar_valued",
-    "validate_tabulated_xy"
+    "validate_tabulated_xy",
+    "validate_covariance_matrix",
 ]
 
 def is_finite_and_differentiable(
@@ -101,3 +102,17 @@ def validate_tabulated_xy(
         raise ValueError("y must be at least 1D.")
 
     return x_arr, y_arr
+
+
+def validate_covariance_matrix(cov: ArrayLike) -> NDArray[np.floating]:
+    """Validates and converts a covariance matrix into a NumPy array."""
+    cov_arr = np.asarray(cov)
+
+    if cov_arr.ndim > 2:
+        raise ValueError(
+            f"cov must be at most two-dimensional; got ndim={cov_arr.ndim}."
+        )
+    if cov_arr.ndim == 2 and cov_arr.shape[0] != cov_arr.shape[1]:
+        raise ValueError(f"cov must be square; got shape={cov_arr.shape}.")
+
+    return cov_arr

--- a/tests/test_forecast_kit_fisher.py
+++ b/tests/test_forecast_kit_fisher.py
@@ -206,18 +206,6 @@ def test_get_forecast_tensors_order1_default_n_workers(forecasting_mocks):
     assert kwargs["n_workers"] == 1
 
 
-def test_normalize_workers_various_inputs():
-    """Tests that _normalize_workers handles various n_workers inputs correctly."""
-    lx = LikelihoodExpansion(function=two_obs_model, theta0=np.zeros(1), cov=np.eye(2))
-
-    assert lx._normalize_workers(1) == 1
-    assert lx._normalize_workers(4) == 4
-    assert lx._normalize_workers(0) == 1
-    assert lx._normalize_workers(-3) == 1
-    assert lx._normalize_workers(None) == 1
-    assert lx._normalize_workers(2.7) == 2
-
-
 @pytest.mark.parametrize("method", ["adaptive", "finite"])
 @pytest.mark.parametrize("extrapolation", ["richardson", "ridders", "gauss_richardson"])
 @pytest.mark.parametrize("stencil", [3, 5, 7, 9])

--- a/tests/test_utils_concurency.py
+++ b/tests/test_utils_concurency.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextvars
 
 from derivkit.utils import concurrency as conc
+from derivkit.utils.concurrency import normalize_workers
 
 
 def _reset_inner_var() -> None:
@@ -113,3 +114,13 @@ def test_parallel_execute_threaded_propagates_inner_workers():
     # Order is preserved because we collect futures in submission order
     assert results == [(10, 4), (20, 4)]
     assert conc._inner_workers_var.get() is None
+
+
+def test_normalize_workers_various_inputs():
+    """Tests that normalize_workers handles various inputs correctly."""
+    assert normalize_workers(1) == 1
+    assert normalize_workers(4) == 4
+    assert normalize_workers(0) == 1
+    assert normalize_workers(-3) == 1
+    assert normalize_workers(None) == 1
+    assert normalize_workers(2.7) == 2


### PR DESCRIPTION
This PR extracts _normalize_workers and the covariance validation logic from LikelihoodExpansion into derivkit.utils (concurrency and validate).

No functional changes — just code relocation and cleanup to prepare for splitting expansions across modules. 

So in steps:

1. moved `_normalize_workers` from LikelihoodExpansion into utils/concurency.py as it makes sense for it to live there (also renamed it to `normalize_workers`)
2. old _nomralize_workers was being called in test_forecasts_kit_fisher so i mvoed that test into test_utils_concurency
3. a small piece of code was actually a covaraince validation (being cehcked at the initialization of LikelihoodExpansion. I have made it into a tiny method and moved into validate and then of course called it at class init.


In total changed 5 files but changes are small.

This is step 1 in getting to solve #195. I want the PR to be small so we are going to do this in small steps.
