### PR TITLE
Split expansions (step 6): Replace test_expansions with testing of forecast_core

### DIFF
--- a/tests/test_forecast_forecast_core.py
+++ b/tests/test_forecast_forecast_core.py
@@ -1,4 +1,4 @@
-"""Tests for LikelihoodExpansion."""
+"""Tests for forecast_core methods."""
 
 from contextlib import nullcontext
 from functools import partial


### PR DESCRIPTION
This PR replaces the calls to LikelihoodExpansion in previously called test_expansion.py (now renamed to test_forecast_forecast_core.py) with methods from forecast_core.

This builds on top of the previous step (pr #276 ).