### PR TITLE
Add automatic deployment of redirect page

### DIFF
--- a/docs/_templates/pages_redirect.html
+++ b/docs/_templates/pages_redirect.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to DerivKit main branch version</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=./main/" />
+    <link rel="canonical" href="https://docs.derivkit.org/main/" />
+  </head>
+</html>
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ PIP_CACHE_DIR = "{tox_root}/.cache/pip"
 [tool.tox.env.docs]
 description = "Build the HTML files using Sphinx"
 extras = ["docs"]
+allowlist_externals = ["cp"]
 commands = [
   [
     "sphinx-apidoc",
@@ -115,6 +116,11 @@ commands = [
     "{tox_root}/docs",
     "{tox_root}/docs/_build/html",
     "--fail-on-warning",
+  ],
+  [
+    "cp",
+    "{tox_root}/docs/_templates/pages_redirect.html",
+    "{tox_root}/docs/_build/html",
   ],
 ]
 


### PR DESCRIPTION
The redirection page I added was overwritten when the docs where redeployed. This means that each time the docs are deployed a new redirection page must be added. Added a small copy step to the `docs` workflow to ensure it is added whenever tox rebuilds the HTML pages.