### PR TITLE
Rename redirect page to index.html

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ commands = [
   [
     "cp",
     "{tox_root}/docs/_templates/pages_redirect.html",
-    "{tox_root}/docs/_build/html",
+    "{tox_root}/docs/_build/html/index.html",
   ],
 ]
 


### PR DESCRIPTION
I forgot that the new redirect page needs to be renamed, because otherwise people still need to manually enter the page name `pages_redirect` to the end of the docs URL.