### PR TITLE
Split expansions (step 8): Replaced calls to LikelihoodExpansions to calls from fisher.py

### DIFF
--- a/tests/test_forecast_kit_fisher_bias.py
+++ b/tests/test_forecast_kit_fisher_bias.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 import pytest
 
-from derivkit.forecasting.expansions import LikelihoodExpansion
+from derivkit.forecasting.fisher import build_delta_nu, build_fisher_bias
 
 A_LINEAR = np.array(
     [
@@ -18,11 +18,13 @@ A_LINEAR = np.array(
 
 def three_obs_model(theta):
     """Model that always returns a 3-element observable vector."""
+    _ = np.atleast_1d(theta)  # this is a phantom use of theta
     return np.zeros(3, dtype=float)
 
 
 def two_obs_model(theta):
     """Model that always returns a 2-element observable vector."""
+    _ = np.atleast_1d(theta)  # this is a phantom use of theta
     return np.zeros(2, dtype=float)
 
 
@@ -37,9 +39,10 @@ linear_model = partial(linear_model_matrix, mat=A_LINEAR)
 
 def check_linear_bias(theta0, cov, fisher, delta_nu, method="finite", **dk_kwargs):
     """Checks that the bias computed for a linear model matches the analytic result."""
-    lx = LikelihoodExpansion(function=linear_model, theta0=theta0, cov=cov)
-
-    bias_vec, delta_theta = lx.build_fisher_bias(
+    bias_vec, delta_theta = build_fisher_bias(
+        function=linear_model,
+        theta0=theta0,
+        cov=cov,
         fisher_matrix=fisher,
         delta_nu=delta_nu,
         method=method,
@@ -90,10 +93,15 @@ def test_build_fisher_bias_exceptions(fisher, delta_nu, expected_exception):
     """Tests that invalid Fisher / delta_nu inputs raise appropriate errors."""
     theta0 = np.array([0.0, 0.0])
     cov = np.eye(3)
-    lx = LikelihoodExpansion(function=linear_model, theta0=theta0, cov=cov)
 
     with pytest.raises(expected_exception):
-        lx.build_fisher_bias(fisher_matrix=fisher, delta_nu=delta_nu)
+        build_fisher_bias(
+            function=linear_model,
+            theta0=theta0,
+            cov=cov,
+            fisher_matrix=fisher,
+            delta_nu=delta_nu,
+        )
 
 
 def test_build_fisher_bias_accepts_2d_delta_nu_and_flattens():
@@ -112,16 +120,18 @@ def test_build_fisher_bias_accepts_2d_delta_nu_and_flattens():
 
     linear_model_4 = partial(linear_model_matrix, mat=mat)
 
-    lx = LikelihoodExpansion(function=linear_model_4, theta0=theta0, cov=cov)
-
     fisher = np.array([[2.0, 0.1], [0.1, 1.5]])
     delta_nu_2d = np.array([[1.0, 2.0], [3.0, 4.0]])  # shape (2, 2) -> flat length 4
 
-    bias_vec, delta_theta = lx.build_fisher_bias(
+    bias_vec, delta_theta = build_fisher_bias(
+        function=linear_model_4,
+        theta0=theta0,
+        cov=cov,
         fisher_matrix=fisher,
         delta_nu=delta_nu_2d,
         method="finite",
     )
+
 
     assert bias_vec.shape == (2,)
     assert delta_theta.shape == (2,)
@@ -131,15 +141,16 @@ def test_build_fisher_bias_accepts_2d_delta_nu_and_flattens():
 
 def test_build_delta_nu_1d_ok():
     """Tests that build_delta_nu works for 1D inputs."""
-    theta0 = np.array([0.0])
     cov = np.eye(4)
-
-    lx = LikelihoodExpansion(function=two_obs_model, theta0=theta0, cov=cov)
 
     data_with = np.array([1.0, 2.0, 3.0, 4.0])
     data_without = np.array([0.5, 1.0, 1.5, 2.0])
 
-    delta = lx.build_delta_nu(data_with=data_with, data_without=data_without)
+    delta = build_delta_nu(
+        cov=cov,
+        data_with=data_with,
+        data_without=data_without,
+    )
 
     expected = data_with - data_without
     assert delta.shape == (4,)
@@ -148,15 +159,16 @@ def test_build_delta_nu_1d_ok():
 
 def test_build_delta_nu_2d_flattens_row_major():
     """Tests that build_delta_nu works for 2D inputs, flattening in row-major order."""
-    theta0 = np.array([0.0])
     cov = np.eye(4)
-
-    lx = LikelihoodExpansion(function=two_obs_model, theta0=theta0, cov=cov)
 
     data_with = np.array([[1.0, 2.0], [3.0, 4.0]])
     data_without = np.array([[0.5, 1.5], [2.0, 2.5]])
 
-    delta = lx.build_delta_nu(data_with=data_with, data_without=data_without)
+    delta = build_delta_nu(
+        cov=cov,
+        data_with=data_with,
+        data_without=data_without,
+    )
 
     expected_2d = data_with - data_without
     expected_flat = expected_2d.ravel(order="C")
@@ -166,25 +178,26 @@ def test_build_delta_nu_2d_flattens_row_major():
 
 
 @pytest.mark.parametrize(
-    "data_with, data_without, model, cov, expected_exception",
+    "data_with, data_without, cov, expected_exception",
     [
         # shape mismatch between with/without
-        (np.zeros(3), np.zeros(4), three_obs_model, np.eye(3), ValueError),
+        (np.zeros(3), np.zeros(4), np.eye(3), ValueError),
         # ndim > 2
-        (np.zeros((2, 2, 1)), np.zeros((2, 2, 1)), two_obs_model, np.eye(4), ValueError),
-        # wrong length vs number of observables
-        (np.zeros((2, 2)), np.zeros((2, 2)), three_obs_model, np.eye(5), ValueError),
+        (np.zeros((2, 2, 1)), np.zeros((2, 2, 1)), np.eye(4), ValueError),
+        # wrong length vs number of observables (flattened length 4 vs n_obs=5)
+        (np.zeros((2, 2)), np.zeros((2, 2)), np.eye(5), ValueError),
         # non-finite values
-        (np.array([0.0, np.nan, 1.0]), np.zeros(3), three_obs_model, np.eye(3), FloatingPointError),
+        (np.array([0.0, np.nan, 1.0]), np.zeros(3), np.eye(3), FloatingPointError),
     ],
 )
-def test_build_delta_nu_exceptions(data_with, data_without, model, cov, expected_exception):
+def test_build_delta_nu_exceptions(data_with, data_without, cov, expected_exception):
     """Tests that invalid inputs to build_delta_nu raise appropriate errors."""
-    theta0 = np.array([0.0])
-    lx = LikelihoodExpansion(function=model, theta0=theta0, cov=cov)
-
     with pytest.raises(expected_exception):
-        lx.build_delta_nu(data_with=data_with, data_without=data_without)
+        build_delta_nu(
+            cov=cov,
+            data_with=data_with,
+            data_without=data_without,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR builds on top of PR Step 7 #280 

In this PR I have changed the calls in test_forecast_kit_fisher_bias to use the method for fisher bias and delta nu directly from fisher.py in forecasting.