### PR TITLE
Split expansions (step 9): Replaced calls to LikelihoodExpansions to calls from dali.py in test_forecast_kit_dali

### DIFF
--- a/tests/test_forecast_kit_dali.py
+++ b/tests/test_forecast_kit_dali.py
@@ -160,7 +160,7 @@ def test_build_dali_symmetry_with_symmetric_inputs(dali_mocks):
 
 
 def test_build_dali_p_equals_one_scalar_case(dali_mocks):
-    """Tests that build_dali handles the scalar P=1 case correctly (shapes + scalar)."""
+    """Tests that build_dali handles the scalar reference value case correctly (shapes + scalar)."""
     n_params = 1
 
     d1 = np.array([[2.0, 3.0]])


### PR DESCRIPTION
This PR builds on top of Step 8 #282 

In this PR I have switched from using LikelihoodExpansions dali to dali.py code in test_forecast_kit_dali.py