### PR TITLE
Split expansions (step 10): Replaced calls to LikelihoodExpansions to calls fom forecast_core in forecastkit_parallel test

### DIFF
--- a/tests/test_forecast_kit_parallel.py
+++ b/tests/test_forecast_kit_parallel.py
@@ -257,7 +257,7 @@ def test_parallel_is_deterministic_across_runs_order2(extra_threads_ok):
 
 
 def test_parallel_preserves_order_with_prime_length_order2(extra_threads_ok):
-    """Verifys derivative ordering is preserved even with uneven parallel splits (order=2).
+    """Verifies derivative ordering is preserved even with uneven parallel splits (order=2).
 
     Using a prime-length input guarantees the workload cannot be divided evenly among
     worker threads. This stresses the chunking/merge logic for second-order derivatives


### PR DESCRIPTION
This PR builds on top of PR Step 9  #283 

In this PR I have changed the calls from LikelihoodExpansion to calls from forecast_core to update the test_forecast_kit_parallel