### PR TITLE
Docs: remove unimplemented Sellentin–Heavens likelihood (#281)

### DIFF
--- a/docs/guide/likelihoods.rst
+++ b/docs/guide/likelihoods.rst
@@ -103,5 +103,4 @@ calculations:
 - likelihoods can be swapped without changing forecasting code.
 
 This modularity allows users to begin with simple Gaussian forecasts
-and later transition to Poisson or Sellentin–Heavens likelihoods
-without rewriting their models.
+and later transition to Poisson likelihood without rewriting their models.


### PR DESCRIPTION
This PR removes the Sellentin–Heavens likelihood section from the LikelihoodKit documentation.
The method is not implemented in DerivKit, and the docs were misleading by implying support.

This closes #281 