### PR TITLE
Fix NumPy deprecation warnings (#269)

### DIFF
--- a/src/derivkit/calculus/hessian.py
+++ b/src/derivkit/calculus/hessian.py
@@ -291,7 +291,12 @@ def _hessian_component_worker(
         n_workers=inner_workers or 1,
         **dk_kwargs,
     )
-    return float(val)
+    val_arr = np.asarray(val, dtype=float)
+    if val_arr.size != 1:
+        raise TypeError(
+            f"Hessian component must be scalar; got array with shape {val_arr.shape}."
+        )
+    return float(val_arr.item())
 
 
 def _hessian_component(
@@ -397,7 +402,12 @@ def _mixed_partial_value(
         n_workers=n_workers,
         **dk_kwargs,
     )
-    return float(val)
+    val_arr = np.asarray(val, dtype=float)
+    if val_arr.size != 1:
+        raise TypeError(
+            f"Mixed partial derivative must be scalar; got array with shape {val_arr.shape}."
+        )
+    return float(val_arr.item())
 
 
 def _build_hessian_internal(

--- a/tests/test_adaptive_fit.py
+++ b/tests/test_adaptive_fit.py
@@ -236,8 +236,11 @@ def test_return_error_with_diagnostics_triplet():
     deriv, err, diag = out
 
     # sanity checks
-    assert np.isfinite(float(deriv))
-    assert np.isfinite(float(err))
+    deriv_arr = np.asarray(deriv)
+    err_arr = np.asarray(err)
+
+    assert np.all(np.isfinite(deriv_arr))
+    assert np.all(np.isfinite(err_arr))
     assert isinstance(diag, dict)
     assert "rrms" in diag
     assert "degree" in diag


### PR DESCRIPTION
This PR removes numpy 1.25 scalar-cast deprecations in hessian code and adaptive-fit tests.
No functional changes; tests now run without warnings. Linting helathy.

This fixes #269 