### PR TITLE
github: add DerivKit adoption issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/derivkit-adoption.yml
+++ b/.github/ISSUE_TEMPLATE/derivkit-adoption.yml
@@ -1,0 +1,41 @@
+name: DerivKit adoption entry
+description: Request that a software project or publication using DerivKit be listed in the docs.
+title: "[Adoption] "
+labels: ["adoption"]
+body:
+  - type: dropdown
+    id: entry_type
+    attributes:
+      label: Entry type
+      description: Where should this be listed on the Citation page?
+      options:
+        - Software / pipeline
+        - Publication
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: e.g., Package Name, Paper title
+    validations:
+      required: true
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact (optional)
+      description: Email or GitHub handle in case maintainers need clarification.
+      placeholder: "@username or name@example.com"
+    validations:
+      required: false
+
+  - type: textarea
+    id: reference
+    attributes:
+      label: Reference (optional)
+      description: For publications, include DOI/arXiv and BibTeX if available.
+      placeholder: DOI/arXiv/BibTeX (optional)
+    validations:
+      required: false


### PR DESCRIPTION
this adds a first try of isse template for adding your code to derivkit citation page

i cannot test this as gh opens issues onl from main


this closes #366 