### PR TITLE
Fix Sphinx version to < 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 test = ["pytest"]
 
 docs = [
-  "sphinx",
+  "sphinx < 9",
   "sphinx-design",
   "sphinx-multiversion",
   "furo",


### PR DESCRIPTION
Sphinx multiversion is incompatible with Sphinx >= 9.0.0. See https://github.com/sphinx-contrib/multiversion/issues/201. Until this has been resolved we should pin the allowed version of Sphinx in our depdendencies.