### PR TITLE
fix index contractions

### DIFF
--- a/src/derivkit/forecasting/forecast_core.py
+++ b/src/derivkit/forecasting/forecast_core.py
@@ -307,7 +307,7 @@ def _get_derivatives(
                 f"hyper_hessian returned unexpected shape {hh_raw.shape}; "
                 f"expected ({n_observables},{n_parameters},{n_parameters},{n_parameters})."
             )
- 
+
 
     else:
         raise ValueError(f"Unsupported value of {order}.")


### PR DESCRIPTION
Index contractions in the forecasting tools are now internally consistent with the output shapes of CalculusKit. Internal shape checks and re-ordering of indices are no longer necessary.