### PR TITLE
Updated DerivativeKit to add a note about n_workers

### DIFF
--- a/src/derivkit/derivative_kit.py
+++ b/src/derivkit/derivative_kit.py
@@ -278,10 +278,10 @@ class DerivativeKit:
             shape ``(5, 2, 3)``.
 
         Notes:
-            The ``n_workers`` keyword (passed via ``**kwargs``) controls thread-level
-            parallelism across derivative evaluations. It does not launch separate
-            Python processes; all work occurs within a single process using worker
-            threads.
+            Thread-level parallelism across derivative evaluations can be
+            controlled by passing ``n_workers`` via ``**kwargs``. Note that
+            this does not launch separate Python processes. All work occurs
+            within a single process using worker threads.
 
         Raises:
             ValueError: If ``method`` is not recognized.


### PR DESCRIPTION
I chose to ad an explanation about what we mean by n_workers  in DerivativeKit.differentiate because it is the best way to do it in one place rather than go in every method. 

If anyone feels strongly, we can add a few workds in every method of derivs but i honestly think it is fine. 


closes #372 and #408