### PR TITLE
Add workflow to publish new versions to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: "Publish new versions of DerivKit to PyPI"
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Build
+        run: uv build
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
Adds a workflow to handle the building and publishing of new versions of DerivKit whenever a new version tag is added. The version tag must be of the form `v*`. In practice, we will probably adhere to the SemVer scheme of versioning.