### PR TITLE
Update CHANGELOG for version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Fixed how `dk_kwargs` are passed to `DerivativeKit`.
+* Fixed how `dk_kwargs` are passed to `ForecastKit`.
 
 
 ## v1.0.1


### PR DESCRIPTION
Fixed the passing of `dk_kwargs` to `DerivativeKit`.