### PR TITLE
Let Github checkout action fetch all branches and tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
This will tell the workflow runner to fetch all branch and tag information. As a result, it can build the documentation for all the version tags that we have released.

This fixes the current situation where only the main branch or version tag that happend to be added is updated. In the current case the documentation may become inaccessible, as we redirect the user to the main branch by default. This is fixed with this new change.

The cost of building all the versions does lead to an increase in processing time. This may or may not be a problem (I don't expect that we will consistently release several versions per day), but it is good to be aware of it.