### PR TITLE
Fix broken docs build on release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,32 +5,34 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   publish_sphinx_docs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          pip install --group dev -e .
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
-      - name: Sphinx build
-        run: |
-          tox -e docs-releases
+      - name: Install tox
+        run: python -m pip install tox
+
+      - name: Build release docs
+        run: tox -e docs-releases
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use tox to manage docs dependencies instead of relying on pip group installs.
Removes brittle setup and ensures consistent Sphinx builds in CI.